### PR TITLE
Build Kanban board UI with dummy data

### DIFF
--- a/src/assets/DummyData.js
+++ b/src/assets/DummyData.js
@@ -1,0 +1,89 @@
+export const project = {
+    id: 'dummy-project',
+    name: 'Dummy Project by Ben',
+    owner: 'dummy-user',
+    contributors: ['du0x00', 'du0x01', 'du0x02'],
+    description: 'This is a dummy project for UI dev before the backend is ready',
+    taskIds: ['tsk0x00', 'tsk0x01', 'tsk0x02', 'tsk0x03', 'tsk0x04', 'tsk0x05', 'tsk0x06', 'tsk0x07', 'tsk0x08', 'tsk0x09'],
+    columns: ['phase0x00', 'phase0x01', 'phase0x02', 'phase0x03'],
+};
+
+export const columns = [
+    {
+        id: 'phase0x00',
+        name: 'Phase 0x00',
+        description: 'This is Phase 0x00',
+        taskList: ['tsk0x00', 'tsk0x01', 'tsk0x08', 'tsk0x09', 'tsk0x07', 'tsk0x05'],
+    },
+    {
+        id: 'phase0x01',
+        name: 'Phase 0x01',
+        description: 'This is Phase 0x01',
+        taskList: [],
+    },
+    {
+        id: 'phase0x02',
+        name: 'Phase 0x02',
+        description: 'This is Phase 0x02',
+        taskList: ['tsk0x03'],
+    },
+    {
+        id: 'phase0x03',
+        name: 'Phase 0x03',
+        description: 'This is Phase 0x03',
+        taskList: ['tsk0x02', 'tsk0x04', 'tsk0x06'],
+    },
+];
+
+export const tasks = [
+    {
+        id: 'tsk0x00',
+        title: 'Task 0x00',
+        description: 'Task 0x00',
+    },
+    {
+        id: 'tsk0x01',
+        title: 'Task 0x01',
+        description: 'Task 0x01',
+    },
+    {
+        id: 'tsk0x02',
+        title: 'Task 0x02',
+        description: 'Task 0x02',
+    },
+    {
+        id: 'tsk0x03',
+        title: 'Task 0x03',
+        description: 'Task 0x03',
+    },
+    {
+        id: 'tsk0x04',
+        title: 'Task 0x04',
+        description: 'Task 0x04',
+    },
+    {
+        id: 'tsk0x05',
+        title: 'Task 0x05',
+        description: 'Task 0x05',
+    },
+    {
+        id: 'tsk0x06',
+        title: 'Task 0x06',
+        description: 'Task 0x06',
+    },
+    {
+        id: 'tsk0x07',
+        title: 'Task 0x07',
+        description: 'Task 0x07',
+    },
+    {
+        id: 'tsk0x08',
+        title: 'Task 0x08',
+        description: 'Task 0x08',
+    },
+    {
+        id: 'tsk0x09',
+        title: 'Task 0x09',
+        description: 'Task 0x09',
+    },
+];

--- a/src/assets/styles/consiliumqTheme.js
+++ b/src/assets/styles/consiliumqTheme.js
@@ -68,6 +68,7 @@ const consiliumqTheme = createMuiTheme({
             main: '#4834d4',
         },
     },
+    projectColumnWidth: 355,
     overrides: {
         MuiCssBaseline: {
             '@global': {

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -48,4 +48,5 @@ $font-stack: Rubik, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Ox
 body {
     font: 100% $font-stack !important;
     background-color: #282c34;
+    margin: 0
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { AppBar, Toolbar, IconButton, makeStyles, FormControl, Select, InputLabel, MenuItem } from '@material-ui/core';
+import { AppBar, Toolbar, IconButton, Button, makeStyles } from '@material-ui/core';
 import { Menu } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 
@@ -18,8 +18,16 @@ const useStyles = makeStyles(theme => ({
         margin: theme.spacing(1),
         minWidth: 120,
     },
-    inputLabel: {
-        color: 'white',
+    button: {
+        boxShadow: 'none',
+        backgroundColor: theme.palette.primary.dark,
+        color: theme.palette.primary.contrastText,
+        '&:hover': {
+            backgroundColor: theme.palette.primary.light,
+        },
+    },
+    icon: {
+        color: theme.palette.primary.contrastText,
     },
 }));
 
@@ -27,39 +35,25 @@ export default function Header(props) {
     const appBarRef = useRef(null);
     const classes = useStyles();
 
-    const [project, setProject] = React.useState('');
-
-    const handleProjectSelection = event => {
-        setProject(event.target.value);
-    };
-
     const { onMenuIconClicked } = props;
 
     return (
         <React.Fragment>
-            <AppBar ref={appBarRef} position={'fixed'} className={classes.root}>
+            <AppBar ref={appBarRef} position={'sticky'} className={classes.root}>
                 <Toolbar>
                     <IconButton edge={'start'} onClick={() => onMenuIconClicked()}>
-                        <Menu />
+                        <Menu className={classes.icon} />
                     </IconButton>
                     <h1>
                         <span style={{ fontWeight: 100 }}>consiliumQ</span>
                     </h1>
                     <div className={classes.spacer} />
-                    <FormControl className={classes.formControl}>
-                        <InputLabel id="demo-simple-select-label" className={classes.inputLabel}>
-                            Select Project
-                        </InputLabel>
-                        <Select labelId="demo-simple-select-label" id="demo-simple-select" value={project} onChange={handleProjectSelection}>
-                            {/* Place holders for now  */}
-                            <MenuItem value={10}>Project1</MenuItem>
-                            <MenuItem value={20}>Project2</MenuItem>
-                            <MenuItem value={30}>Project3</MenuItem>
-                        </Select>
-                    </FormControl>
+                    <Button variant={'contained'} onClick={() => console.log('should open dialog')} className={classes.button}>
+                        {'Placeholder'}
+                    </Button>
                 </Toolbar>
             </AppBar>
-            <Toolbar style={{ height: appBarRef.clientHeight }} />
+            {/* <Toolbar style={{ height: appBarRef.height }} /> */}
         </React.Fragment>
     );
 }

--- a/src/components/KanbanBoard/KanbanBoard.js
+++ b/src/components/KanbanBoard/KanbanBoard.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { Button, makeStyles } from '@material-ui/core';
+import { Add } from '@material-ui/icons';
+import { KanbanColumn } from '..';
+import { project } from '../../assets/DummyData';
+
+const useStyles = makeStyles(theme => ({
+    horizontalColumnList: {
+        display: 'flex',
+        justifyContent: 'flex-start',
+        flexWrap: 'nowrap',
+        flexGrow: 1,
+        overflow: 'auto',
+    },
+    addColumnButton: {
+        height: theme.spacing(10),
+        border: `2px dashed ${theme.palette.primary.light}`,
+        backgroundColor: theme.palette.primary.dark,
+        borderRadius: theme.spacing(1),
+        color: theme.palette.primary.contrastText,
+        flexGrow: 1,
+        boxShadow: 'none',
+        '&:hover': {
+            backgroundColor: theme.palette.primary.light,
+            border: 0,
+        },
+    },
+    buttonColumn: {
+        minWidth: theme.projectColumnWidth,
+        padding: 5,
+        borderRight: `1px solid ${theme.palette.primary.light}`,
+        display: 'flex',
+    },
+}));
+
+// custom hook for changing the height of kanban board based on window.innerHeight
+// this behavior mimics the Project feature of GitHub, but the performance is a little concerning
+const useBoardHeight = () => {
+    const [boardHeight, setBoardHeight] = useState(window.innerHeight - 85);
+
+    const setBoardHeightOnListen = () => setBoardHeight(window.innerHeight - 85);
+    useEffect(() => {
+        window.addEventListener('resize', setBoardHeightOnListen);
+        return () => {
+            window.removeEventListener('resize', setBoardHeightOnListen);
+        };
+    });
+
+    return boardHeight;
+};
+
+export default function KanbanBoard() {
+    // TODO: receive data from GraphQL server
+    const classes = useStyles();
+    const boardHeight = useBoardHeight();
+
+    return (
+        <div className={classes.horizontalColumnList} style={{ height: boardHeight }}>
+            {project.columns.map((columnId, index) => (
+                <KanbanColumn isLastColumn={index === project.columns.length - 1} key={columnId} columnId={columnId} />
+            ))}
+            <div className={classes.buttonColumn}>
+                <Button
+                    startIcon={<Add />}
+                    variant={'contained'}
+                    onClick={() => console.log('Add Column Button Click!')}
+                    className={classes.addColumnButton}
+                >
+                    {'Add Column'}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/KanbanColumn/KanbanColumn.js
+++ b/src/components/KanbanColumn/KanbanColumn.js
@@ -1,39 +1,63 @@
-import React, { useState, useEffect } from 'react';
-import { Card, CardContent, CardActions, IconButton, Container, Grid, Divider, makeStyles, List, ListItem } from '@material-ui/core';
-import { EditOutlined, MoreVertOutlined } from '@material-ui/icons';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles, List, ListSubheader } from '@material-ui/core';
 import { TaskCard } from '..';
+import { columns } from '../../assets/DummyData';
 
 const useStyles = makeStyles(theme => ({
     kanbanColumn: {
-        height: window.innerHeight - 150,
-        borderLeftWidth: 1,
-        borderLeftColor: theme.palette.primary.light,
-        borderLeftStyle: 'solid',
-        borderRightWidth: 1,
-        borderRightColor: theme.palette.primary.light,
-        borderRightStyle: 'solid',
+        borderLeft: `1px solid ${theme.palette.primary.light}`,
+        borderRight: props => (props.isLastColumn ? `1px solid ${theme.palette.primary.light}` : 0),
+        minWidth: theme.projectColumnWidth,
+        overflow: 'auto',
+    },
+    tasksContainer: {
+        paddingLeft: 5,
+        paddingRight: 5,
         '& li': {
             padding: 0,
             justifyContent: 'center',
             alignItems: 'center',
+            '& h2': {
+                margin: 0,
+                width: '100%',
+                color: theme.palette.primary.contrastText,
+            },
         },
+    },
+    columnHeader: {
+        textAlign: 'center',
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
     },
 }));
 
-export default function KanbanColumn(props) {
-    const classes = useStyles();
-    const TaskCardItems = () => (
-        <>
-            {props.tasks.map(task => (
-                <ListItem key={task}>
-                    <TaskCard task={task} />
-                </ListItem>
-            ))}
-        </>
+export default function KanbanColumn({ isLastColumn, columnId }) {
+    const classes = useStyles({ isLastColumn });
+    const column = columns.find(col => col.id === columnId);
+
+    const ColumnHeader = () => (
+        <ListSubheader className={classes.columnHeader} disableGutters>
+            <h2>{column.name}</h2>
+        </ListSubheader>
     );
+
     return (
-        <List className={classes.kanbanColumn}>
-            <TaskCardItems />
-        </List>
+        <div className={classes.kanbanColumn}>
+            <List subheader={<ColumnHeader />} className={classes.tasksContainer}>
+                {column.taskList.map(taskId => (
+                    <TaskCard key={taskId} taskId={taskId} />
+                ))}
+            </List>
+        </div>
     );
 }
+
+KanbanColumn.defaultProps = {
+    isLastColumn: false,
+};
+
+KanbanColumn.propTypes = {
+    isLastColumn: PropTypes.bool,
+    columnId: PropTypes.string.isRequired,
+};

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -13,16 +13,14 @@ const useStyles = makeStyles(theme => ({
         width: 300,
         backgroundColor: theme.palette.primary.main,
         flexGrow: 1,
-        paddingTop: '3rem',
     },
     bigAvatar: {
         margin: 10,
         width: 120,
         height: 120,
-        marginBottom: '3rem',
     },
     chip: {
-        marginTop: '2rem',
+        marginTop: theme.spacing(2),
         backgroundColor: theme.palette.primary.contrastText,
         color: theme.palette.primary.light,
         fontSize: '130%',
@@ -32,7 +30,7 @@ const useStyles = makeStyles(theme => ({
         fontSize: '110%',
     },
     divider: {
-        backgroundColor: theme.palette.primary.contrastText,
+        backgroundColor: theme.palette.primary.light,
     },
 }));
 
@@ -44,13 +42,13 @@ export default function SideBar(props) {
 
     return (
         <Drawer className={classes.drawer} open={props.shouldSideBarOpen} onClose={() => props.toggleSideBar()}>
-            <div className={classes.list} role="presentation">
-                <Grid container justify="center" alignItems="center">
-                    <Avatar alt="prettymj" src={mijeong} className={classes.bigAvatar} />
+            <div className={classes.list} role={'presentation'}>
+                <Grid container justify={'center'} alignItems={'center'}>
+                    <Avatar alt={'prettymj'} src={mijeong} className={classes.bigAvatar} />
                 </Grid>
                 <Divider className={classes.divider} />
-                <Grid container justify="center" alignItems="center">
-                    <Chip className={classes.chip} label="Overview" />
+                <Grid container justify={'center'} alignItems={'center'}>
+                    <Chip className={classes.chip} label={'Overview'} />
                 </Grid>
                 <List>
                     {['Visualization', 'Backlogs'].map((text, index) => (
@@ -63,8 +61,8 @@ export default function SideBar(props) {
                     ))}
                 </List>
                 <Divider className={classes.divider} />
-                <Grid container justify="center" alignItems="center">
-                    <Chip className={classes.chip} label="Your Projects" />
+                <Grid container justify={'center'} alignItems={'center'}>
+                    <Chip className={classes.chip} label={'Your Projects'} />
                 </Grid>
                 <List>
                     {['Project1', 'Project'].map((text, index) => (

--- a/src/components/TaskCard/TaskCard.js
+++ b/src/components/TaskCard/TaskCard.js
@@ -1,10 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { Card, CardContent, CardActions, IconButton, Container, Grid, Divider, makeStyles } from '@material-ui/core';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card, CardContent, CardActions, IconButton, ListItem, makeStyles } from '@material-ui/core';
 import { EditOutlined, MoreVertOutlined } from '@material-ui/icons';
+import { tasks } from '../../assets/DummyData';
 
 const useStyles = makeStyles(theme => ({
     cardContainer: {
-        width: 275,
+        width: '100%',
         maxHeight: 206.25,
         backgroundColor: theme.palette.secondary.main,
         marginTop: theme.spacing(1),
@@ -32,20 +34,28 @@ const useStyles = makeStyles(theme => ({
 
 export default function TaskCard(props) {
     const classes = useStyles();
+    const task = tasks.find(tsk => tsk.id === props.taskId);
+
     return (
-        <Card className={classes.cardContainer}>
-            <CardContent>
-                <h3>{`Title ${props.task}`}</h3>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.</p>
-            </CardContent>
-            <CardActions classes={{ root: classes.iconPosition }}>
-                <IconButton size={'small'} onClick={() => console.log('icon button clicked!')}>
-                    <EditOutlined className={classes.icon} />
-                </IconButton>
-                <IconButton size={'small'} onClick={() => console.log('icon button click')}>
-                    <MoreVertOutlined className={classes.icon} />
-                </IconButton>
-            </CardActions>
-        </Card>
+        <ListItem>
+            <Card className={classes.cardContainer}>
+                <CardContent>
+                    <h3>{task.title}</h3>
+                    <p>{task.description}</p>
+                </CardContent>
+                <CardActions classes={{ root: classes.iconPosition }}>
+                    <IconButton size={'small'} onClick={() => console.log('icon button clicked!')}>
+                        <EditOutlined className={classes.icon} />
+                    </IconButton>
+                    <IconButton size={'small'} onClick={() => console.log('icon button click')}>
+                        <MoreVertOutlined className={classes.icon} />
+                    </IconButton>
+                </CardActions>
+            </Card>
+        </ListItem>
     );
 }
+
+TaskCard.propTypes = {
+    taskId: PropTypes.string.isRequired,
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,3 +2,4 @@ export { default as Header } from './Header/Header';
 export { default as SideBar } from './Sidebar/Sidebar';
 export { default as TaskCard } from './TaskCard/TaskCard';
 export { default as KanbanColumn } from './KanbanColumn/KanbanColumn';
+export { default as KanbanBoard } from './KanbanBoard/KanbanBoard';

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -1,30 +1,14 @@
 import React, { useState } from 'react';
-import { Paper, Grid } from '@material-ui/core';
-import { makeStyles } from '@material-ui/styles';
 
-import { Header, TaskCard, SideBar, KanbanColumn } from '../../components';
+import { Header, SideBar, KanbanBoard } from '../../components';
 
 const HomePage = () => {
     const [shouldSideBarOpen, setSideBarOpen] = useState(false);
 
-    const dummyData = Array.from(Array(3).keys());
     return (
         <>
             <Header onMenuIconClicked={() => setSideBarOpen(!shouldSideBarOpen)} />
-            <Grid container style={{ paddingTop: '16px' }}>
-                <Grid item xs={12} md={4} lg={3}>
-                    <KanbanColumn tasks={dummyData} />
-                </Grid>
-                <Grid item xs={12} md={4} lg={3}>
-                    <KanbanColumn tasks={[dummyData[0]]} />
-                </Grid>
-                <Grid item xs={12} md={4} lg={3}>
-                    <KanbanColumn tasks={[]} />
-                </Grid>
-                <Grid item xs={12} md={4} lg={3}>
-                    <KanbanColumn tasks={dummyData.slice(0, 2)} />
-                </Grid>
-            </Grid>
+            <KanbanBoard />
             <SideBar shouldSideBarOpen={shouldSideBarOpen} toggleSideBar={() => setSideBarOpen(!shouldSideBarOpen)} />
         </>
     );


### PR DESCRIPTION
### This PR

- Build the homepage UI with Kanban board using dummy data
  - extract the Kanban board view from homepage because it's quite important and with be reuse in the major project page.
- Change some styling of `<Header />` and `<SideBar />` according to the feedback from @halfundecided 

### This revision

- is the first revision (as I closed the previous PR)

### Screen shot

> what the UI looks like in the PR

<img width="1440" alt="Screen Shot 2019-11-06 at 21 43 29" src="https://user-images.githubusercontent.com/42496006/68356298-e8b36780-00df-11ea-8523-a12137832b40.png">

<img width="1440" alt="Screen Shot 2019-11-06 at 21 43 49" src="https://user-images.githubusercontent.com/42496006/68356305-ed781b80-00df-11ea-919c-5b53800e6c93.png">

<img width="1440" alt="Screen Shot 2019-11-06 at 21 43 41 1" src="https://user-images.githubusercontent.com/42496006/68356311-f36dfc80-00df-11ea-8537-95fb39a333af.png">
